### PR TITLE
Fixed typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ Usage
 =====
 
 Install it: [how to][usage], [what plugin version to use][version].
-`npm install --save zopfli- brunch` should do the trick. Make sure that it is listed _after_ any CSS
+`npm install --save zopfli-brunch` should do the trick. Make sure that it is listed _after_ any CSS
 preprocessors in the dependencies.
 
 You can specify the browsers you want to target in your project:


### PR DESCRIPTION
`npm install --save zopfli -brunch` -> `npm install --save zopfli-brunch`
