### PR TITLE
Do not use unsupported styles

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -4,7 +4,6 @@ module.exports = class AutoprefixerCompiler
 	brunchPlugin: yes
 	type: "stylesheet"
 	extension: "css"
-	pattern: /\.(?:css|scss|sass|less|styl)$/
 
 	constructor: (@config)->
 		{@browsers} = @config.plugins.autoprefixer ? {}


### PR DESCRIPTION
Somehow it recognizes all stylesheets as CSS. See https://github.com/brunch/sass-brunch/issues/35 for more detail. Excluding the stylesheets should be fine as Brunch pass those files through the preprocessors first anyway.
